### PR TITLE
Add freeze instruction in Bit Field

### DIFF
--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -1673,6 +1673,10 @@ void CodeGenFunction::EmitStoreThroughBitfieldLValue(RValue Src, LValue Dst,
   // Cast the source to the storage type and shift it into place.
   SrcVal = Builder.CreateIntCast(SrcVal, Ptr.getElementType(),
                                  /*IsSigned=*/false);
+
+  // Freeze SrcVal.
+  SrcVal = Builder.CreateFreeze(SrcVal);
+
   llvm::Value *MaskedVal = SrcVal;
 
   // See if there are other bits in the bitfield's storage we'll need to load
@@ -1681,6 +1685,9 @@ void CodeGenFunction::EmitStoreThroughBitfieldLValue(RValue Src, LValue Dst,
     assert(Info.StorageSize > Info.Size && "Invalid bitfield size.");
     llvm::Value *Val =
       Builder.CreateLoad(Ptr, Dst.isVolatileQualified(), "bf.load");
+
+    // Freeze loaded value.
+    Val = Builder.CreateFreeze(Val);
 
     // Mask the source value as needed.
     if (!hasBooleanRepresentation(Dst.getType()))


### PR DESCRIPTION
Added freeze instruction at `EmitStoreThroughBitfieldLValue`.

I checked that generated IR code of storing a value into a bitfield (`a.x = t`) contains newly inserted freeze instructions. I freezed both `a.x` and `t`, because otherwise other fields in `a` still can be undef value.

I checked this using C/C++ sample code. Here is the following code.

C : 

```
struct A{
  int x:3;
  int y:6;
  int z:7;
};

int f1(int arg){
  int value = arg;
  struct A a;
  a.y = value;
  return a.y + 1234;
}
```

IR : 

```
%struct.A = type { i16, [2 x i8] }
%union.B = type { i8, [3 x i8] }

; Function Attrs: nounwind uwtable
define i32 @f1(i32 %arg) #0 {
entry:
  ; JuneyoungLee : Declarations
  %arg.addr = alloca i32, align 4
  %value = alloca i32, align 4
  %a = alloca %struct.A, align 4
  store i32 %arg, i32* %arg.addr, align 4
  %0 = load i32, i32* %arg.addr, align 4
  store i32 %0, i32* %value, align 4
  ; C statement : a.y = value;
  ; Step 1) Load `value` and `a`
  %1 = load i32, i32* %value, align 4
  %2 = bitcast %struct.A* %a to i16*
  %3 = trunc i32 %1 to i16
  %4 = freeze i16 %3
  %bf.load = load i16, i16* %2, align 4
  %5 = freeze i16 %bf.load
  ; Step 2) Calculate updated value using bit operations
  %bf.value = and i16 %4, 63
  %bf.shl = shl i16 %bf.value, 3
  %bf.clear = and i16 %5, -505
  %bf.set = or i16 %bf.clear, %bf.shl
  ; Step 3) Store the updated value into alloca
  store i16 %bf.set, i16* %2, align 4
  ; Step 4) Save the result into registers so that it could be used later
  %bf.result.shl = shl i16 %bf.value, 10
  %bf.result.ashr = ashr i16 %bf.result.shl, 10
  %bf.result.cast = sext i16 %bf.result.ashr to i32
  ; C statement : return (unsigned int)a.y + 1234;
  %6 = bitcast %struct.A* %a to i16*
  %bf.load1 = load i16, i16* %6, align 4
   %bf.shl2 = shl i16 %bf.load1, 7    
   %bf.ashr = ashr i16 %bf.shl2, 10   
   %bf.cast = sext i16 %bf.ashr to i32
   %add = add nsw i32 %bf.cast, 1234  
  ret i32 %add
}
```

I attach sample codes (run.c / run.c.O0.ll / run.cpp / run.cpp.O0ll).
[bitfield.zip](https://github.com/snu-sf/clang-freeze/files/429232/bitfield.zip)
