### PR TITLE
Remove redundant freeze when loading bitfield.

### DIFF
--- a/lib/CodeGen/CGExpr.cpp
+++ b/lib/CodeGen/CGExpr.cpp
@@ -1675,7 +1675,7 @@ void CodeGenFunction::EmitStoreThroughBitfieldLValue(RValue Src, LValue Dst,
                                  /*IsSigned=*/false);
 
   // Freeze SrcVal.
-  SrcVal = Builder.CreateFreeze(SrcVal);
+  //SrcVal = Builder.CreateFreeze(SrcVal);
 
   llvm::Value *MaskedVal = SrcVal;
 


### PR DESCRIPTION
I removed redundant freeze when loading bitfield.

Now it freezes only lhs of `a.x = value`.